### PR TITLE
Add tile_suffix_mask and quadint2xy to the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,24 @@ The fast technique for quadkey encodig/decoding is taken from https://github.com
 
 ## Available Methods
 
-`lonlat2quadint(lon, lat)`
+Conversion functions:
+`xy2quadint(x, y)`
+* Input: x, y coordinates based on WebMercator in the range [0,2^31)
+* Output: quadint value
 
+`quadint2xy(quadkey)`
+* Input: quadint value
+* Output: x, y coordinates based on WebMercator in the range [0,2^31)
+
+`lonlat2quadint(lon, lat)`
 * Input: longitude, latitude in WGS84 (SRID 4326) coordinates in degrees
 * Output: quadint value
 
-`webmercator2quadint(x, y)`
+`webmercator2xy(x, y)`
+* Input:  (float) web mercator coordinates (SRID 3857)
+* Output: (int) x, y coordinates based on WebMercator in the range [0,2^31)
 
+`webmercator2quadint(x, y)`
 * Input:  web mercator coordinates (SRID 3857)
 * Output: quadint value
 
@@ -60,10 +71,15 @@ Functions to handle tiles (defined by a quadint value and a zoom level)
 * Input: quadint value and zoom level
 * Output: quadint values of the 4 children of the tile of level zoom+1
 
-`tile_mask(quadint, zoom)`
+`tile_mask(zoom)`
 
 * Input: zoom level
 * Output: quadint mask to select tiles of the level (with bitwise AND)
+
+`tile_suffix_mask(zoom)`
+
+* Input: zoom level
+* Output: quadint mask to select the significant bits from a zoom level (with bitwise AND)
 
 Conversion of tile representation between quadint, zoom and x, y zoom:
 

--- a/quadkey.c
+++ b/quadkey.c
@@ -1044,7 +1044,7 @@ lonlat2xy_py(PyObject* self, PyObject* args)
 
 static PyMethodDef QuadkeyMethods[] =
 {
-     {"xy2quadint", xy2quadint_py, METH_VARARGS, "xy2quadint_py"},
+     {"xy2quadint", xy2quadint_py, METH_VARARGS, "xy2quadint"},
      {"quadint2xy", quadint2xy_py, METH_VARARGS, "quadint2xy"},
      {"lonlat2quadint", lonlat2quadint_py, METH_VARARGS, "lonlat2quadint"},
      {"xy2webmercator", xy2webmercator_py, METH_VARARGS, "xy2webmercator"},

--- a/quadkey.c
+++ b/quadkey.c
@@ -869,6 +869,17 @@ webmercator2quadint_py(PyObject* self, PyObject* args)
     return Py_BuildValue("K", xy2quadint(x, y));
 }
 
+static PyObject*
+quadint2xy_py(PyObject* self, PyObject* args)
+{
+    uint64 quadint;
+    if (!PyArg_ParseTuple(args, "K", &quadint))
+        return NULL;
+    uint32 result_x, result_y;
+    quadint2xy(quadint, &result_x, &result_y);
+    return Py_BuildValue("ii", result_x, result_y);
+}
+
 /*
  Input: 62-bit quadkey value
  Output:  web mercator bounding box coordinates (SRID 3857)
@@ -1034,6 +1045,7 @@ lonlat2xy_py(PyObject* self, PyObject* args)
 static PyMethodDef QuadkeyMethods[] =
 {
      {"xy2quadint", xy2quadint_py, METH_VARARGS, "xy2quadint_py"},
+     {"quadint2xy", quadint2xy_py, METH_VARARGS, "quadint2xy"},
      {"lonlat2quadint", lonlat2quadint_py, METH_VARARGS, "lonlat2quadint"},
      {"xy2webmercator", xy2webmercator_py, METH_VARARGS, "xy2webmercator"},
      {"webmercator2xy", webmercator2xy_py, METH_VARARGS, "webmercator2xy"},

--- a/quadkey.c
+++ b/quadkey.c
@@ -934,6 +934,17 @@ tile_mask_py(PyObject* self, PyObject* args)
 }
 
 static PyObject*
+tile_suffix_mask_py(PyObject* self, PyObject* args)
+{
+    int zoom;
+
+    if (!PyArg_ParseTuple(args, "i", &zoom))
+        return NULL;
+
+    return Py_BuildValue("K", tile_suffix_mask(zoom));
+}
+
+static PyObject*
 tile_center_webmercator_py(PyObject* self, PyObject* args)
 {
     uint64 quadint;
@@ -1031,6 +1042,7 @@ static PyMethodDef QuadkeyMethods[] =
      {"tile2bbox", tile2bbox_py, METH_VARARGS, "tile2bbox"},
      {"tile2range", tile2range_py, METH_VARARGS, "tile2range"},
      {"tile_mask", tile_mask_py, METH_VARARGS, "tile_mask"},
+     {"tile_suffix_mask", tile_suffix_mask_py, METH_VARARGS, "tile_suffix_mask"},
      {"tile_center_webmercator", tile_center_webmercator_py, METH_VARARGS, "tile_center_webmercator"},
      {"tile_center", tile_center_py, METH_VARARGS, "tile_center"},
      {"tile_children", tile_children_py, METH_VARARGS, "tile_children"},


### PR DESCRIPTION
Couple of commits to add these two functions to the python API. Also I've updated the documentation (at least the part related to conversions) so it should fix https://github.com/CartoDB/python-quadkey/issues/3

