### PR TITLE
Update quadkey.c fix for M_PI on windows

### DIFF
--- a/quadkey.c
+++ b/quadkey.c
@@ -31,6 +31,10 @@ typedef unsigned int uint32;
 #endif
 #endif
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
+
 
 static inline uint64
 xy2quadint(uint64 x, uint64 y)


### PR DESCRIPTION
See [here](https://stackoverflow.com/questions/26065359/m-pi-flagged-as-undeclared-identifier)

There are a variety of fixes on that page but this seems like the most straightforward and compiled with no issues for me on windows.